### PR TITLE
Simplify PromQL for k8s Grafana dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Grafana 5 dashboards for Dashbase
 
-Just add the contents within `provisioning` to `/etc/grafana/provisioning/` and restart your Grafana. 
+Just add the contents within `provisioning` to `/etc/grafana/provisioning/` and restart your Grafana.
 
 Or you can set up a Prometheus datasource manually and import these [dashboards](https://github.com/dashbase/grafana-dashboards/tree/master/provisioning/dashboards).
 ![image](https://i.gyazo.com/24334c1b7f29b18ae4ff41c105c72e03.png)
+
+How to update dashboards:
+
+If you want to update the dashboards under provisioning/dashboards, please use Grafana 5 deployed on Kubernetes.
+
+If you want to update the dashboards under dashboards_swarm/, then please use Grafana 5 deployed onto Swarm.

--- a/provisioning/dashboards/Dashbase Overview.json
+++ b/provisioning/dashboards/Dashbase Overview.json
@@ -159,17 +159,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(rate(dashbase_ingestion_events_total{component='table',app='$app'}[$duration]) * on(instance) group_left(table_partition,table_name) dashbase_table_info) by (table_partition,table_name)) by (table_name)",
+          "expr": "sum(avg(rate(dashbase_ingestion_events_total{component='table',app='$app'}[$duration])) by (table,partition)) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "# events - {{table_name}}",
+          "legendFormat": "# events - {{table}}",
           "refId": "A"
         },
         {
-          "expr": "sum(avg(rate(dashbase_ingestion_event_bytes_total{component='table',app='$app'}[$duration]) * on(instance) group_left(table_partition,table_name) dashbase_table_info) by (table_partition,table_name)) by (table_name)",
+          "expr": "sum(avg(rate(dashbase_ingestion_event_bytes_total{component='table',app='$app'}[$duration])) by (table,partition)) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "# bytes - {{table_name}}",
+          "legendFormat": "# bytes - {{table}}",
           "refId": "B"
         }
       ],
@@ -259,7 +259,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(dashbase_dashbase_api_query_latency_count{app='$app'}[$duration])",
+          "expr": "avg(rate(dashbase_dashbase_api_query_latency_count{app='$app'}[$duration]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "QPS",
@@ -366,10 +366,10 @@
           "refId": "A"
         },
         {
-          "expr": "avg(jvm_cpu_usage_percent{component='table',app='$app'} * on(instance) group_left(table_name) dashbase_table_info) by (table_name)",
+          "expr": "avg(jvm_cpu_usage_percent{component='table',app='$app'}) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "table - {{table_name}}",
+          "legendFormat": "table - {{table}}",
           "refId": "B"
         }
       ],
@@ -459,10 +459,10 @@
           "refId": "A"
         },
         {
-          "expr": "avg(jvm_memory_heap_usage{component='table',app='$app'} * on(instance) group_left(table_name) dashbase_table_info) by (table_name)",
+          "expr": "avg(jvm_memory_heap_usage{component='table',app='$app'}) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "table - {{table_name}}",
+          "legendFormat": "table - {{table}}",
           "refId": "B"
         }
       ],

--- a/provisioning/dashboards/Dashbase Proxy.json
+++ b/provisioning/dashboards/Dashbase Proxy.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1539025650677,
+  "iteration": 1539818306105,
   "links": [],
   "panels": [
     {
@@ -281,7 +281,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(io_dashbase_esproxy_api_IndexAPI_bulk_count{app='$app'}[$duration]))",
+          "expr": "sum(rate(io_dashbase_esproxy_api_IndexAPI_bulkPost_count{app='$app'}[$duration]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -289,7 +289,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(io_dashbase_esproxy_api_IndexAPI_bulk_exceptions_total{app='$app'}[$duration]))",
+          "expr": "sum(rate(io_dashbase_esproxy_api_IndexAPI_bulkPost_exceptions_total{app='$app'}[$duration]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -297,21 +297,21 @@
           "refId": "B"
         },
         {
-          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulk{quantile='0.5',app='$app'})",
+          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulkPost{quantile='0.5',app='$app'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "latency (p50)",
           "refId": "C"
         },
         {
-          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulk{quantile='0.95',app='$app'})",
+          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulkPost{quantile='0.95',app='$app'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "latency (p95)",
           "refId": "D"
         },
         {
-          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulk{quantile='0.99',app='$app'})",
+          "expr": "avg(io_dashbase_esproxy_api_IndexAPI_bulkPost{quantile='0.99',app='$app'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "latency (p99)",
@@ -321,7 +321,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Input - _bulk endpoint",
+      "title": "Input - _bulk POST endpoint",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -663,8 +663,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "staging",
-          "value": "staging"
+          "text": "dashbase",
+          "value": "dashbase"
         },
         "datasource": "Prometheus",
         "hide": 0,
@@ -774,5 +774,5 @@
   "timezone": "",
   "title": "Dashbase Proxy",
   "uid": "WBh5iVpiz",
-  "version": 2
+  "version": 1
 }

--- a/provisioning/dashboards/Dashbase Table.json
+++ b/provisioning/dashboards/Dashbase Table.json
@@ -75,17 +75,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(dashbase_ingestion_events_total[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(rate(dashbase_ingestion_events_total{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "events - {{table_name}} - {{table_partition}}",
+          "legendFormat": "events - {{table}} - {{partition}}",
           "refId": "C"
         },
         {
-          "expr": "avg(rate(dashbase_ingestion_event_bytes_total[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(rate(dashbase_ingestion_event_bytes_total{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": " bytes - {{table_name}} - {{table_partition}}",
+          "legendFormat": " bytes - {{table}} - {{partition}}",
           "refId": "D"
         }
       ],
@@ -168,17 +168,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(dashbase_indexer_delayInSec * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "min(dashbase_indexer_delayInSec{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "ingestion - {{table_name}} - {{table_partition}}",
+          "legendFormat": "ingestion - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "min(dashbase_search_reader_delayInSec * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "min(dashbase_search_reader_delayInSec{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "indexing - {{table_name}} - {{table_partition}}",
+          "legendFormat": "indexing - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -261,17 +261,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(dashbase_ingestion_parse_error_total[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(rate(dashbase_ingestion_parse_error_total{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "parse error - {{table_name}} - {{table_partition}}",
+          "legendFormat": "parse error - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(rate(dashbase_ingestion_parse_skipped_total[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(rate(dashbase_ingestion_parse_skipped_total{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "skipped - {{table_name}} - {{table_partition}}",
+          "legendFormat": "skipped - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -354,17 +354,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p50 - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.99'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.99'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p99 - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -460,10 +460,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_lag_max * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_lag_max{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{table_name}} - {{table_partition}}",
+          "legendFormat": "{{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -551,17 +551,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_consumed_rate * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_consumed_rate{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "records - {{table_name}} - {{table_partition}}",
+          "legendFormat": "records - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_bytes_consumed_rate * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_bytes_consumed_rate{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "bytes - {{table_name}} - {{table_partition}}",
+          "legendFormat": "bytes - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -657,17 +657,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(dashbase_search_query_latency_count[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "sum(rate(dashbase_search_query_latency_count{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "total - {{table_name}} - {{table_partition}}",
+          "legendFormat": "total - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(dashbase_search_slow_query_total[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "sum(rate(dashbase_search_slow_query_total{table=~'${table:pipe}',app='$app'}[$duration])) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "slow query - {{table_name}} - {{table_partition}}",
+          "legendFormat": "slow query - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -750,17 +750,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_search_query_latency{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_search_query_latency{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p50 - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_search_query_latency{quantile='0.99'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_search_query_latency{table=~'${table:pipe}',app='$app',quantile='0.99'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p99 - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -856,17 +856,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_index_timeslice_count * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_index_timeslice_count{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "timeslice (total) - {{table_name}} - {{table_partition}}",
+          "legendFormat": "timeslice (total) - {{table}} - {{partition}}",
           "refId": "B"
         },
         {
-          "expr": "avg(dashbase_search_reader_cache_count * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_search_reader_cache_count{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "reader (cached) - {{table_name}} - {{table_partition}}",
+          "legendFormat": "reader (cached) - {{table}} - {{partition}}",
           "refId": "A"
         }
       ],
@@ -949,17 +949,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_search_wait_latency{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition  )",
+          "expr": "avg(dashbase_search_wait_latency{quantile='0.5',table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p50 - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_search_wait_latency{quantile='0.99'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition  )",
+          "expr": "avg(dashbase_search_wait_latency{quantile='0.99',table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p99 - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -1055,10 +1055,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_cpu_usage_percent{component='table'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(jvm_cpu_usage_percent{component='table',table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{table_name}} - {{table_partition}}",
+          "legendFormat": "{{table}} - {{partition}}",
           "refId": "A"
         }
       ],
@@ -1147,17 +1147,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_memory_heap_used{component='table'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(jvm_memory_heap_used{component='table',table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{table_name}} - {{table_partition}}",
+          "legendFormat": "{{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(jvm_memory_heap_max{component='table'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(jvm_memory_heap_max{component='table',table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "max - {{table_name}} - {{table_partition}}",
+          "legendFormat": "max - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
@@ -1245,17 +1245,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_total_payload_bytes * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_total_payload_bytes{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "raw bytes - {{table_name}} - {{table_partition}}",
+          "legendFormat": "raw bytes - {{table}} - {{partition}}",
           "refId": "B"
         },
         {
-          "expr": "avg(dashbase_total_index_bytes / dashbase_disk_total_bytes * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_total_index_bytes{table=~'${table:pipe}',app='$app'} / dashbase_disk_total_bytes{table=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "% used - {{table_name}} - {{table_partition}}",
+          "legendFormat": "% used - {{table}} - {{partition}}",
           "refId": "A"
         }
       ],
@@ -1344,7 +1344,7 @@
         "multi": true,
         "name": "table",
         "options": [],
-        "query": "label_values(dashbase_table_info{app='$app'}, table_name)",
+        "query": "label_values(dashbase_table_info{app='$app'}, table)",
         "refresh": 1,
         "regex": "",
         "sort": 0,


### PR DESCRIPTION
This PR simplifies the PromQL queries for Grafana dashboards for k8s by removing `* on(instance) group_left(...)`, which was added by https://github.com/dashbase/grafana-dashboards/pull/9. 

tl;dr; please use Grafana deployed onto k8s to update the dashboards under `provisioning/dashboards`, and then use Grafana deployed on Swarm to update the dashboards under `dashboards_swarm/`.

Prometheus k8s service discover module can add k8s annotations as metric labels, so the metrics from Table will have `table` and partition` labels, so we can just group the metrics by those labels. Prometheus on Swarm is using DNS service discovery, which doesn't have this capability, so we need to join `instance` metric (which contains `table_name` and `table_partition` labels).

Also found out that one of the graphs in Proxy's dashboard is broken (as we added `PUT` and `POST` methods for `_bulk`), so this PR also fixes it.