### PR TITLE
Fix/Improve Table dashboard

### DIFF
--- a/dashboards_swarm/Dashbase Table.json
+++ b/dashboards_swarm/Dashbase Table.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1542758610021,
+  "iteration": 1542839502883,
   "links": [],
   "panels": [
     {
@@ -137,6 +137,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "Time spent to build each segment",
       "fill": 0,
       "gridPos": {
         "h": 9,
@@ -144,17 +145,17 @@
         "x": 12,
         "y": 1
       },
-      "id": 8,
+      "id": 20,
       "legend": {
         "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": true,
         "max": false,
         "min": false,
         "rightSide": true,
         "show": true,
         "sort": "current",
-        "sortDesc": false,
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -172,27 +173,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(dashbase_indexer_delayInSec * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "ingestion - {{table_name}} - {{table_partition}}",
+          "legendFormat": "{{table_name}} - {{table_partition}}",
           "refId": "A"
         },
         {
-          "expr": "min(dashbase_search_reader_delayInSec * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.99'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
           "format": "time_series",
+          "hide": true,
           "intervalFactor": 1,
-          "legendFormat": "indexing - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p99 - {{table_name}} - {{table_partition}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Delay",
+      "title": "Latency",
       "tooltip": {
         "shared": true,
-        "sort": 1,
+        "sort": 0,
         "value_type": "individual"
       },
       "type": "graph",
@@ -205,7 +207,7 @@
       },
       "yaxes": [
         {
-          "format": "s",
+          "format": "ns",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -232,6 +234,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "{Time when a segment was built} - {timestamp of each event}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -267,17 +270,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_indexing_full_latency_secs * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_indexing_full_latency_secs{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{table_name}} - {{table_partition}}",
+          "legendFormat": "p50 - {{table_name}} - {{table_partition}}",
           "refId": "A"
+        },
+        {
+          "expr": "avg(dashbase_indexing_full_latency_secs{quantile='0.999'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p999 - {{table_name}} - {{table_partition}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Full Latency",
+      "title": "Delay",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -319,15 +329,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 0,
+      "datasource": null,
+      "description": "{newest timestamp in a segment} - {oldest timestamp in a segment}",
+      "fill": 1,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 10
       },
-      "id": 20,
+      "id": 50,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -355,27 +366,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_time_slice_range_secs{quantile='0.5'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 - {{table_name}} - {{table_partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{quantile='0.99'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "expr": "avg(dashbase_time_slice_range_secs{quantile='0.999'} * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 - {{table_name}} - {{table_partition}}",
+          "legendFormat": "p999 - {{table_name}} - {{table_partition}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Latency",
+      "title": "Timeslice Range",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -388,7 +399,7 @@
       },
       "yaxes": [
         {
-          "format": "ns",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -396,7 +407,7 @@
           "show": true
         },
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -490,94 +501,6 @@
         },
         {
           "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 19
-      },
-      "id": 50,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg(dashbase_time_slice_range_secs * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{table_name}} - {{table_partition}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Timeslice Range",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -957,7 +880,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Latency",
+      "title": "Response Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1674,6 +1597,92 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 77
+      },
+      "id": 54,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(jvm_gc_G1_Young_Generation_time[$duration]) * on(instance) group_left(table_name,table_partition) dashbase_table_info{table_name=~'${table:pipe}',app='$app'}) by (table_name,table_partition)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{table_name}} - {{table_partition}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GC time spent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -2312,7 +2321,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
           "text": "dashbase-us-west-2",
           "value": "dashbase-us-west-2"
         },
@@ -2336,8 +2344,6 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "tags": [],
           "text": "All",
           "value": [
             "$__all"
@@ -2426,5 +2432,5 @@
   "timezone": "",
   "title": "Dashbase Table",
   "uid": "YhMqAJtmk",
-  "version": 1
+  "version": 2
 }

--- a/provisioning/dashboards/Dashbase Table.json
+++ b/provisioning/dashboards/Dashbase Table.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1542676786647,
+  "iteration": 1542837615093,
   "links": [],
   "panels": [
     {
@@ -137,6 +137,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "Time spent to build each segment",
       "fill": 0,
       "gridPos": {
         "h": 9,
@@ -144,10 +145,10 @@
         "x": 12,
         "y": 1
       },
-      "id": 8,
+      "id": 20,
       "legend": {
         "alignAsTable": true,
-        "avg": true,
+        "avg": false,
         "current": true,
         "max": false,
         "min": false,
@@ -172,24 +173,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(dashbase_indexer_delayInSec{table=~'${table:pipe}',app='$app'}) by (table,partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "ingestion - {{table}} - {{partition}}",
+          "legendFormat": "{{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "min(dashbase_search_reader_delayInSec{table=~'${table:pipe}',app='$app'}) by (table,partition)",
+          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.99'}) by (table,partition)",
           "format": "time_series",
+          "hide": true,
           "intervalFactor": 1,
-          "legendFormat": "indexing - {{table}} - {{partition}}",
+          "legendFormat": "p99 - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Delay",
+      "title": "Latency",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -205,7 +207,7 @@
       },
       "yaxes": [
         {
-          "format": "s",
+          "format": "ns",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -233,6 +235,7 @@
       "dashes": false,
       "datasource": null,
       "decimals": null,
+      "description": "{Time when a segment was built} - {timestamp of each event}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -268,17 +271,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_indexing_full_latency_secs{table=~'${table:pipe}',app='$app'}) by (table,partition)",
+          "expr": "avg(dashbase_indexing_full_latency_secs{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{table}} - {{partition}}",
+          "legendFormat": "p50 - {{table}} - {{partition}}",
           "refId": "A"
+        },
+        {
+          "expr": "avg(dashbase_indexing_full_latency_secs{table=~'${table:pipe}',app='$app',quantile='0.999'}) by (table,partition)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "p999 - {{table}} - {{partition}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Full Latency",
+      "title": "Delay",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -320,15 +331,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 0,
+      "datasource": null,
+      "description": "{newest timestamp in a segment} - {oldest timestamp in a segment}",
+      "fill": 1,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 10
       },
-      "id": 20,
+      "id": 51,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -356,24 +368,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
+          "expr": "avg(dashbase_time_slice_range_secs{table=~'${table:pipe}',app='$app',quantile='0.5'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 - {{table}} - {{partition}}",
           "refId": "A"
         },
         {
-          "expr": "avg(dashbase_indexed_full_index_duration{table=~'${table:pipe}',app='$app',quantile='0.99'}) by (table,partition)",
+          "expr": "avg(dashbase_time_slice_range_secs{table=~'${table:pipe}',app='$app',quantile='0.999'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 - {{table}} - {{partition}}",
+          "legendFormat": "p999 - {{table}} - {{partition}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Latency",
+      "title": "Timeslice Range",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -389,7 +401,7 @@
       },
       "yaxes": [
         {
-          "format": "ns",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -397,7 +409,7 @@
           "show": true
         },
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -504,94 +516,6 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 19
-      },
-      "id": 51,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "sort": "current",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg(dashbase_time_slice_range_secs{table=~'${table:pipe}',app='$app'}) by (table,partition)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{table}} - {{partition}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Timeslice Range",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -645,7 +569,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_lag_max{table=~'${table:pipe}',app='$app'}) by (table,partition)",
+          "expr": "avg(clamp_min(dashbase_firehose_kafka_consumer_fetch_manager_metrics_records_lag_max{table=~'${table:pipe}',app='$app'},0)) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{table}} - {{partition}}",
@@ -958,7 +882,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Latency",
+      "title": "Response Time",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1798,7 +1722,7 @@
           "expr": "avg(dashbase_disk_used_bytes{table_name=~'${table:pipe}',app='$app'}) by (table,partition)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "index bytes - {{table_name}} - {{table_partition}}",
+          "legendFormat": "index bytes - {{table}} - {{partition}}",
           "refId": "B"
         },
         {
@@ -2644,6 +2568,7 @@
         "allValue": null,
         "current": {
           "selected": true,
+          "tags": [],
           "text": "5m",
           "value": "5m"
         },


### PR DESCRIPTION
- Use `dashbase_indexing_full_latency_secs` instead of `dashbase_indexer_delayInSec ` for `Delay` graph, and fix the query to show p50 and p999 (it was averaging over all quantiles :( ). Also put description as "{Time when a segment was built} - {timestamp of each event}" (correct me if this is wrong @zengmin2016 )
- Put the description of `Latency` graph as "Time spent to build each segment", and the description of `Timeslice Range` as "{newest timestamp in a segment} - {oldest timestamp in a segment}"

![image](https://user-images.githubusercontent.com/847884/48872291-5b2b1a80-ed9d-11e8-8f14-0ff702b254b5.png)
