### PR TITLE
Add table filter for prometheus & nightwatch

### DIFF
--- a/provisioning/dashboards/Filebeat Monitor.json
+++ b/provisioning/dashboards/Filebeat Monitor.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1556052507813,
+  "iteration": 1556002184520,
   "links": [],
   "panels": [
     {
@@ -79,7 +78,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(nightwatch_metric_file_append_total_size{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(nightwatch_metric_file_append_total_size{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -211,7 +210,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(http_libbeat_output_write_bytes{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(http_libbeat_output_write_bytes{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -353,7 +352,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "http_filebeat_harvester_running{host=~\"${hostname:pipe}\"}",
+          "expr": "http_filebeat_harvester_running{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -474,7 +473,7 @@
       "targets": [
         {
           "alias": "skipped - $tag_host",
-          "expr": "http_filebeat_harvester_skipped{host=~\"${hostname:pipe}\"}",
+          "expr": "http_filebeat_harvester_skipped{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -517,7 +516,7 @@
         },
         {
           "alias": "truncated - $tag_host",
-          "expr": "http_filebeat_input_log_files_truncated{host=~\"${hostname:pipe}\"}",
+          "expr": "http_filebeat_input_log_files_truncated{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -655,7 +654,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(http_filebeat_events_added{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(http_filebeat_events_added{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -784,7 +783,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "http_filebeat_events_active{host=~\"${hostname:pipe}\"}",
+          "expr": "http_filebeat_events_active{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -904,7 +903,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(http_filebeat_events_done{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(http_filebeat_events_done{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1049,7 +1048,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(http_libbeat_output_events_active{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(http_libbeat_output_events_active{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1179,7 +1178,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "rate(http_libbeat_output_events_acked{host=~\"${hostname:pipe}\"}[5m])",
+          "expr": "rate(http_libbeat_output_events_acked{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[5m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1306,7 +1305,7 @@
       "targets": [
         {
           "alias": "read - $tag_host",
-          "expr": "rate(http_libbeat_output_read_errors{host=~\"${hostname:pipe}\"}[1m])",
+          "expr": "rate(http_libbeat_output_read_errors{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[1m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1349,7 +1348,7 @@
         },
         {
           "alias": "write - $tag_host",
-          "expr": "rate(http_libbeat_output_write_errors{host=~\"${hostname:pipe}\"}[1m])",
+          "expr": "rate(http_libbeat_output_write_errors{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}[1m])",
           "format": "time_series",
           "groupBy": [
             {
@@ -1487,7 +1486,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "http_system_load_norm_5{host=~\"${hostname:pipe}\"}",
+          "expr": "http_system_load_norm_5{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -1622,7 +1621,7 @@
       "targets": [
         {
           "alias": "$tag_host",
-          "expr": "http_beat_memstats_memory_alloc{host=~\"${hostname:pipe}\"}",
+          "expr": "http_beat_memstats_memory_alloc{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -1725,18 +1724,49 @@
       {
         "allValue": ".*",
         "current": {
+          "tags": [],
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(http_filebeat_events_active,host)",
+        "definition": "label_values(http_filebeat_events_active, host)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "hostname",
         "options": [],
-        "query": "label_values(http_filebeat_events_active,host)",
+        "query": "label_values(http_filebeat_events_active, host)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(http_filebeat_events_active, table)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "table",
+        "options": [],
+        "query": "label_values(http_filebeat_events_active, table)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/provisioning/dashboards/NightWatch Monitor.json
+++ b/provisioning/dashboards/NightWatch Monitor.json
@@ -1085,7 +1085,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {

--- a/provisioning/dashboards/NightWatch Monitor.json
+++ b/provisioning/dashboards/NightWatch Monitor.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
-  "iteration": 1556052898490,
+  "iteration": 1556001524683,
   "links": [],
   "panels": [
     {
@@ -71,7 +70,7 @@
       "targets": [
         {
           "alias": "$tag_host Local",
-          "expr": "nightwatch_verify_local_count{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_local_count{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -109,7 +108,7 @@
         },
         {
           "alias": "$tag_host Local",
-          "expr": "nightwatch_verify_dashbase_count{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_dashbase_count{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -232,7 +231,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "nightwatch_verify_count_delta_percentile{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_count_delta_percentile{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -240,7 +239,7 @@
           "refId": "A"
         },
         {
-          "expr": "nightwatch_verify_count_delta{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_count_delta{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -340,7 +339,7 @@
       "targets": [
         {
           "alias": "$tag_host Local",
-          "expr": "nightwatch_verify_local_count{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_local_count{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -469,7 +468,7 @@
       "targets": [
         {
           "alias": "$tag_host file counts",
-          "expr": "nightwatch_verify_local_used_nanosecond{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_local_used_nanosecond{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -585,7 +584,7 @@
       "targets": [
         {
           "alias": "$tag_host file counts",
-          "expr": "nightwatch_verify_dashbase_query_used_nanosecond{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_verify_dashbase_query_used_nanosecond{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -701,7 +700,7 @@
       "targets": [
         {
           "alias": "$tag_host file counts",
-          "expr": "nightwatch_count_local_used_nanosecond{host=~\"${hostname:pipe}\"}",
+          "expr": "nightwatch_count_local_used_nanosecond{host=~\"${hostname:pipe}\", table=~\"${table:pipe}\"}",
           "format": "time_series",
           "groupBy": [
             {
@@ -831,7 +830,7 @@
           "targets": [
             {
               "alias": "$tag_host",
-              "expr": "http_system_load_norm_5{host=~\"${hostname}\"}",
+              "expr": "http_system_load_norm_5{host=~\"${hostname}\", table=~\"${table:pipe}\"}",
               "format": "time_series",
               "groupBy": [
                 {
@@ -967,7 +966,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "http_beat_memstats_memory_alloc{host=~\"${hostname}\"}",
+              "expr": "http_beat_memstats_memory_alloc{host=~\"${hostname}\", table=~\"${table:pipe}\"}",
               "format": "time_series",
               "interval": "1m",
               "intervalFactor": 1,
@@ -1030,18 +1029,49 @@
       {
         "allValue": ".*",
         "current": {
+          "tags": [],
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(nightwatch_metric_as_count,host)",
+        "definition": "label_values(nightwatch_metric_as_count, host)",
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "hostname",
         "options": [],
-        "query": "label_values(nightwatch_metric_as_count,host)",
+        "query": "label_values(nightwatch_metric_as_count, host)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(nightwatch_metric_as_count, table)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "table",
+        "options": [],
+        "query": "label_values(nightwatch_metric_as_count, table)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1055,7 +1085,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
Added "table" filter for filebeat and nightwatch dashboard so that we could find hosts easily.
The filter is from Prometheus label which is pushed by `telegraf`.
![image](https://user-images.githubusercontent.com/19381524/56561412-aad67200-65d9-11e9-98d9-159d047525e6.png)

