### PR TITLE
api dashboard filtering on table

### DIFF
--- a/provisioning/dashboards/Dashbase API.json
+++ b/provisioning/dashboards/Dashbase API.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 15,
-  "iteration": 1557440239052,
+  "iteration": 1562804135298,
   "links": [],
   "panels": [
     {
@@ -91,7 +90,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(dashbase_query_count{app=\"$app\", component=\"api\"}[1h]))",
+          "expr": "sum(increase(dashbase_query_count{app=\"$app\", component=\"api\", table=\"$table\"}[1h]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -149,7 +148,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(dashbase_query_count{app=\"$app\", component=\"api\"}[$duration])) by (table)",
+          "expr": "sum(rate(dashbase_query_count{app=\"$app\", component=\"api\", table=\"$table\"}[$duration])) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{table}}",
@@ -235,7 +234,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (sum by (account,table) (rate(dashbase_query_count{app=\"$app\",component=\"api\"}[$duration]))) > 0",
+          "expr": "sum (sum by (account,table) (rate(dashbase_query_count{app=\"$app\",component=\"api\",table=\"$table\"}[$duration]))) > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "users / sec",
@@ -838,9 +837,8 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "staging",
-          "value": "staging"
+          "text": "dashbase",
+          "value": "dashbase"
         },
         "datasource": "Prometheus",
         "definition": "",
@@ -866,8 +864,8 @@
         "current": {
           "selected": false,
           "tags": [],
-          "text": "5m",
-          "value": "5m"
+          "text": "1m",
+          "value": "1m"
         },
         "hide": 0,
         "includeAll": false,
@@ -894,11 +892,39 @@
         "query": "1m,5m,15m",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "intraswitch",
+          "value": [
+            "intraswitch"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(dashbase_table_info, table)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "table",
+        "options": [],
+        "query": "label_values(dashbase_table_info, table)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -929,5 +955,5 @@
   "timezone": "",
   "title": "Dashbase API",
   "uid": "0yjWFPgZk",
-  "version": 8
+  "version": 1
 }

--- a/provisioning/dashboards/Dashbase API.json
+++ b/provisioning/dashboards/Dashbase API.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1562804135298,
+  "iteration": 1562869516246,
   "links": [],
   "panels": [
     {
@@ -90,7 +90,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(dashbase_query_count{app=\"$app\", component=\"api\", table=\"$table\"}[1h]))",
+          "expr": "sum(increase(dashbase_query_count{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[1h]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -148,7 +148,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(dashbase_query_count{app=\"$app\", component=\"api\", table=\"$table\"}[$duration])) by (table)",
+          "expr": "sum(rate(dashbase_query_count{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[$duration])) by (table)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{table}}",
@@ -234,7 +234,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (sum by (account,table) (rate(dashbase_query_count{app=\"$app\",component=\"api\",table=\"$table\"}[$duration]))) > 0",
+          "expr": "sum (sum by (account,table) (rate(dashbase_query_count{app=\"$app\",component=\"api\",table=~'${table:pipe}'}[$duration]))) > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "users / sec",
@@ -837,8 +837,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "dashbase",
-          "value": "dashbase"
+          "text": "staging",
+          "value": "staging"
         },
         "datasource": "Prometheus",
         "definition": "",
@@ -864,8 +864,8 @@
         "current": {
           "selected": false,
           "tags": [],
-          "text": "1m",
-          "value": "1m"
+          "text": "5m",
+          "value": "5m"
         },
         "hide": 0,
         "includeAll": false,
@@ -897,9 +897,10 @@
         "allValue": null,
         "current": {
           "tags": [],
-          "text": "intraswitch",
+          "text": "nginx-json + logmatters",
           "value": [
-            "intraswitch"
+            "nginx-json",
+            "logmatters"
           ]
         },
         "datasource": "Prometheus",
@@ -924,7 +925,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -955,5 +956,5 @@
   "timezone": "",
   "title": "Dashbase API",
   "uid": "0yjWFPgZk",
-  "version": 1
+  "version": 10
 }


### PR DESCRIPTION
Modified dashboard to be able to filter on table

Still some issues:

* `Query Response Time` Dashboard cannot be filtered on table, because the metric does not have the table label
* `Query Count(Last Hour)` Dashboard shows over 350 queries in an hour for the intraswitch table. Let's verify it that it's true, query is: ```sum(increase(dashbase_query_count{app="$app", component="api"}[1h]))```
* Selecting `All Tables` does not work.