### PR TITLE
Use $table to filter

### DIFF
--- a/provisioning/dashboards/Dashbase Overview.json
+++ b/provisioning/dashboards/Dashbase Overview.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1566928676482,
+  "iteration": 1566963798790,
   "links": [],
   "panels": [
     {
@@ -509,7 +509,7 @@
           "refId": "N"
         },
         {
-          "expr": "sum(label_replace(increase(nightwatch_metric_file_append_total_size{table=~\"$app-$table\"}[24h]), \"table\", \"$1\", \"table\", \"$app-(.*)\")) by (table)",
+          "expr": "sum(increase(nightwatch_metric_file_append_total_size{table=~\"$table$\"}[24h])) by (table)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1860,7 +1860,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 41
           },
           "id": 108,
           "legend": {
@@ -1885,7 +1885,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -1994,7 +1994,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 41
           },
           "id": 109,
           "legend": {
@@ -2016,7 +2016,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2121,7 +2121,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 50
           },
           "id": 110,
           "legend": {
@@ -2147,7 +2147,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2224,7 +2224,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 50
           },
           "id": 111,
           "legend": {
@@ -2249,7 +2249,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2324,7 +2324,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 59
           },
           "id": 112,
           "legend": {
@@ -2348,7 +2348,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2430,7 +2430,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 59
           },
           "id": 113,
           "legend": {
@@ -2454,7 +2454,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2520,7 +2520,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -2553,7 +2553,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 41
           },
           "id": 115,
           "legend": {
@@ -2578,7 +2578,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2687,7 +2687,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 41
           },
           "id": 116,
           "legend": {
@@ -2709,7 +2709,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2814,7 +2814,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 50
           },
           "id": 117,
           "legend": {
@@ -2840,7 +2840,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2917,7 +2917,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 50
           },
           "id": 118,
           "legend": {
@@ -2942,7 +2942,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3017,7 +3017,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 59
           },
           "id": 119,
           "legend": {
@@ -3041,7 +3041,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3123,7 +3123,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 59
           },
           "id": 120,
           "legend": {
@@ -3147,7 +3147,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3213,7 +3213,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -3246,7 +3246,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 41
           },
           "id": 122,
           "legend": {
@@ -3271,7 +3271,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3380,7 +3380,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 41
           },
           "id": 123,
           "legend": {
@@ -3402,7 +3402,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3507,7 +3507,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 50
           },
           "id": 124,
           "legend": {
@@ -3533,7 +3533,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3610,7 +3610,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 50
           },
           "id": 125,
           "legend": {
@@ -3635,7 +3635,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3710,7 +3710,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 59
           },
           "id": 126,
           "legend": {
@@ -3734,7 +3734,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3816,7 +3816,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 59
           },
           "id": 127,
           "legend": {
@@ -3840,7 +3840,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3906,7 +3906,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -3939,7 +3939,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 41
           },
           "id": 129,
           "legend": {
@@ -3964,7 +3964,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4073,7 +4073,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 41
           },
           "id": 130,
           "legend": {
@@ -4095,7 +4095,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4200,7 +4200,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 50
           },
           "id": 131,
           "legend": {
@@ -4226,7 +4226,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4303,7 +4303,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 50
           },
           "id": 132,
           "legend": {
@@ -4328,7 +4328,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4403,7 +4403,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 63
+            "y": 59
           },
           "id": 133,
           "legend": {
@@ -4427,7 +4427,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4509,7 +4509,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 63
+            "y": 59
           },
           "id": 134,
           "legend": {
@@ -4533,7 +4533,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4599,7 +4599,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -4632,7 +4632,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 41
           },
           "id": 136,
           "legend": {
@@ -4657,7 +4657,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4766,7 +4766,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 41
           },
           "id": 137,
           "legend": {
@@ -4788,7 +4788,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4893,7 +4893,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 50
           },
           "id": 138,
           "legend": {
@@ -4919,7 +4919,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4996,7 +4996,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 50
           },
           "id": 139,
           "legend": {
@@ -5021,7 +5021,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5096,7 +5096,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 59
           },
           "id": 140,
           "legend": {
@@ -5120,7 +5120,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5202,7 +5202,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 59
           },
           "id": 141,
           "legend": {
@@ -5226,7 +5226,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5292,7 +5292,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -5325,7 +5325,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 41
           },
           "id": 143,
           "legend": {
@@ -5350,7 +5350,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5459,7 +5459,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 41
           },
           "id": 144,
           "legend": {
@@ -5481,7 +5481,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5586,7 +5586,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 50
           },
           "id": 145,
           "legend": {
@@ -5612,7 +5612,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5689,7 +5689,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 50
           },
           "id": 146,
           "legend": {
@@ -5714,7 +5714,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5789,7 +5789,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 59
           },
           "id": 147,
           "legend": {
@@ -5813,7 +5813,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5895,7 +5895,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 59
           },
           "id": 148,
           "legend": {
@@ -5919,7 +5919,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5985,7 +5985,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -6018,7 +6018,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 41
           },
           "id": 150,
           "legend": {
@@ -6043,7 +6043,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6152,7 +6152,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 41
           },
           "id": 151,
           "legend": {
@@ -6174,7 +6174,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6279,7 +6279,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 50
           },
           "id": 152,
           "legend": {
@@ -6305,7 +6305,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6382,7 +6382,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 50
           },
           "id": 153,
           "legend": {
@@ -6407,7 +6407,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6482,7 +6482,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 59
           },
           "id": 154,
           "legend": {
@@ -6506,7 +6506,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6588,7 +6588,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 66
+            "y": 59
           },
           "id": 155,
           "legend": {
@@ -6612,7 +6612,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6678,7 +6678,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -6711,7 +6711,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 41
           },
           "id": 157,
           "legend": {
@@ -6736,7 +6736,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6845,7 +6845,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 41
           },
           "id": 158,
           "legend": {
@@ -6867,7 +6867,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -6972,7 +6972,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 50
           },
           "id": 159,
           "legend": {
@@ -6998,7 +6998,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7075,7 +7075,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 50
           },
           "id": 160,
           "legend": {
@@ -7100,7 +7100,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7175,7 +7175,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 59
           },
           "id": 161,
           "legend": {
@@ -7199,7 +7199,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7281,7 +7281,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 59
           },
           "id": 162,
           "legend": {
@@ -7305,7 +7305,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7371,7 +7371,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -7404,7 +7404,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 41
           },
           "id": 164,
           "legend": {
@@ -7429,7 +7429,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 22,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7538,7 +7538,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 41
           },
           "id": 165,
           "legend": {
@@ -7560,7 +7560,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 47,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7665,7 +7665,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 50
           },
           "id": 166,
           "legend": {
@@ -7691,7 +7691,7 @@
           "renderer": "flot",
           "repeat": null,
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 14,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7768,7 +7768,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 50
           },
           "id": 167,
           "legend": {
@@ -7793,7 +7793,7 @@
           "points": false,
           "renderer": "flot",
           "repeatDirection": "v",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7868,7 +7868,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 59
           },
           "id": 168,
           "legend": {
@@ -7892,7 +7892,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 16,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7974,7 +7974,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 59
           },
           "id": 169,
           "legend": {
@@ -7998,7 +7998,7 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1566928676482,
+          "repeatIteration": 1566963798790,
           "repeatPanelId": 18,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8064,7 +8064,7 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": 1566928676482,
+      "repeatIteration": 1566963798790,
       "repeatPanelId": 30,
       "scopedVars": {
         "table": {
@@ -8111,7 +8111,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "All",
           "value": [
             "$__all"
@@ -8228,5 +8227,5 @@
   "timezone": "",
   "title": "Dashbase Overview",
   "uid": "qwOotTpik",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
We used to use lable_replace to filter Nightwatch table name with "$app-$table", but it is not a stander env. 
After we merge this PR
https://github.com/dashbase/dashbase-deployment/pull/485
We should change it back to the normal way.
`sum(increase(nightwatch_metric_file_append_total_size{table=~"$table$"}[24h])) by (table)`