### PR TITLE
only show # of events dropped from full segments

### DIFF
--- a/provisioning/dashboards/Dashbase Indexer.json
+++ b/provisioning/dashboards/Dashbase Indexer.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1591832184203,
+  "iteration": 1592349092204,
   "links": [],
   "panels": [
     {
@@ -1435,7 +1435,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(dashbase_indexer_events_dropped{component='indexer', table=~'${table:pipe}',app='$app'}[$duration])) by ($per)",
+          "expr": "sum(rate(dashbase_indexer_events_dropped{component='indexer', table=~'${table:pipe}',app='$app',type='full'}[$duration])) by ($per)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "evets dropped - {{$per}}",
@@ -2722,5 +2722,5 @@
   "timezone": "",
   "title": "Dashbase Indexer",
   "uid": "2kC2zlsZz",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
Exabeam's Indexer dashboard is showing that some events were dropped. I checked their logs, and found out that it's due to some error building realtime segments. in other words, Indexer did not drop any event when building full segments.

https://web.staging.dashbase.io/search?query=%22Unexpected%20error%20building%22&tables=%5B%22exabeam-logs%22%5D&timeEnd=1592301539691&timeStart=1592175600691&page=0&useUTC=false&rawResults=false&selectedFields=%5B%5D

this PR is modifying the "Number of Events Dropped" graph to only show the # of events dropped from full segments.