### PR TITLE
DB-2356 Add Template Upload Rate graph to Indexer & Table dashboards

### DIFF
--- a/provisioning/dashboards/Dashbase Indexer.json
+++ b/provisioning/dashboards/Dashbase Indexer.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1593125546916,
+  "iteration": 1595573615437,
   "links": [],
   "panels": [
     {
@@ -840,12 +840,98 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 117,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dashbase_etcd_dispatcher_put{component='indexer',registry='template',action='sent'}[$duration])) by (key)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{key}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Template Update Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 46
       },
       "id": 66,
       "panels": [],
@@ -862,7 +948,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 47
       },
       "id": 68,
       "legend": {
@@ -957,7 +1043,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 47
       },
       "id": 70,
       "legend": {
@@ -1043,7 +1129,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 56
       },
       "id": 86,
       "legend": {
@@ -1129,7 +1215,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 56
       },
       "id": 88,
       "legend": {
@@ -1211,7 +1297,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 65
       },
       "id": 35,
       "panels": [],
@@ -1228,7 +1314,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 66
       },
       "id": 94,
       "legend": {
@@ -1344,7 +1430,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 66
       },
       "id": 18,
       "legend": {
@@ -1437,7 +1523,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 75
       },
       "id": 111,
       "legend": {
@@ -1525,7 +1611,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 75
       },
       "id": 112,
       "legend": {
@@ -1612,7 +1698,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 75
+        "y": 84
       },
       "id": 31,
       "legend": {
@@ -1700,7 +1786,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 75
+        "y": 84
       },
       "id": 109,
       "legend": {
@@ -1800,7 +1886,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 84
+        "y": 93
       },
       "id": 102,
       "legend": {
@@ -1897,7 +1983,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 84
+        "y": 93
       },
       "id": 103,
       "legend": {
@@ -2004,7 +2090,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 93
+        "y": 102
       },
       "id": 49,
       "legend": {
@@ -2110,7 +2196,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 93
+        "y": 102
       },
       "id": 107,
       "legend": {
@@ -2193,7 +2279,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 111
       },
       "id": 14,
       "panels": [],
@@ -2211,7 +2297,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 112
       },
       "id": 37,
       "legend": {
@@ -2300,7 +2386,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 112
       },
       "id": 2,
       "legend": {
@@ -2389,7 +2475,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 121
       },
       "id": 4,
       "legend": {
@@ -2490,7 +2576,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 121
       },
       "id": 55,
       "legend": {
@@ -2585,7 +2671,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 121
+        "y": 130
       },
       "id": 6,
       "legend": {
@@ -2840,5 +2926,5 @@
   "timezone": "",
   "title": "Dashbase Indexer",
   "uid": "2kC2zlsZz",
-  "version": 8
+  "version": 9
 }

--- a/provisioning/dashboards/Dashbase Table.json
+++ b/provisioning/dashboards/Dashbase Table.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1593125856342,
+  "iteration": 1595573959965,
   "links": [],
   "panels": [
     {
@@ -1417,6 +1417,92 @@
         },
         {
           "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "id": 111,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dashbase_etcd_dispatcher_put{component='table',registry='template',action='sent'}[$duration])) by (key)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{key}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Template Update Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -5041,5 +5127,5 @@
   "timezone": "",
   "title": "Dashbase Table",
   "uid": "YhMqAJtmk",
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
query is `sum(rate(dashbase_etcd_dispatcher_put{component='indexer',registry='template',action='sent'}[$duration])) by (key)`