### PR TITLE
show max cpu instead of avg to be more precise

### DIFF
--- a/provisioning/dashboards/Dashbase Indexer.json
+++ b/provisioning/dashboards/Dashbase Indexer.json
@@ -2416,7 +2416,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_cpu_usage_percent{component='indexer',table=~'${table:pipe}',app='$app'}) by ($per)",
+          "expr": "max(jvm_cpu_usage_percent{component='indexer',table=~'${table:pipe}',app='$app'}) by ($per)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$per}}",

--- a/provisioning/dashboards/Dashbase Searcher.json
+++ b/provisioning/dashboards/Dashbase Searcher.json
@@ -813,7 +813,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "jvm_cpu_usage_percent{component='searcher',app='$app'}",
+          "expr": "max(jvm_cpu_usage_percent{component='searcher',app='$app'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",

--- a/provisioning/dashboards/Dashbase Table Manager.json
+++ b/provisioning/dashboards/Dashbase Table Manager.json
@@ -926,7 +926,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_cpu_usage_percent{component='table-manager',table=~'${table:pipe}',app='$app'}) by ($per)",
+          "expr": "max(jvm_cpu_usage_percent{component='table-manager',table=~'${table:pipe}',app='$app'}) by ($per)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$per}}",

--- a/provisioning/dashboards/Dashbase Table.json
+++ b/provisioning/dashboards/Dashbase Table.json
@@ -4484,7 +4484,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_cpu_usage_percent{component='table',table=~'${table:pipe}',app='$app'}) by ($per)",
+          "expr": "max(jvm_cpu_usage_percent{component='table',table=~'${table:pipe}',app='$app'}) by ($per)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{$per}}",


### PR DESCRIPTION
CPU metrics are show average, which is misleading because does not show spikes that can cause problems for the cluster. Changing to max to be more correct.