### PR TITLE
Update Searcher Dashboard

### DIFF
--- a/provisioning/dashboards/Dashbase Searcher.json
+++ b/provisioning/dashboards/Dashbase Searcher.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1603918598625,
+  "iteration": 1603918598639,
   "links": [],
   "panels": [
     {
@@ -484,7 +484,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 19
@@ -587,14 +587,118 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "the number of payload readers loaded into in-memory cache",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "dashbase_searcher_payload_cache_size{component=\"searcher\",app=\"$app\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(dashbase_searcher_payload_cache_size{component=\"indexer\",app=\"$app\"}) by ($per)",
+          "format": "time_series",
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "realtime - {{$per}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Payload Reader Cached",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
       "description": "the number of segment readers loaded into in-memory cache",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 19
+        "x": 0,
+        "y": 28
       },
       "hiddenSeries": false,
       "id": 11,
@@ -690,17 +794,16 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "the number of payload readers loaded into in-memory cache",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
-        "x": 0,
-        "y": 27
+        "x": 12,
+        "y": 28
       },
       "hiddenSeries": false,
-      "id": 32,
+      "id": 41,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -714,7 +817,6 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [],
       "nullPointMode": "null",
       "options": {
         "dataLinks": []
@@ -729,29 +831,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "dashbase_searcher_payload_cache_size{component=\"searcher\",app=\"$app\"}",
-          "format": "time_series",
-          "hide": false,
+          "expr": "avg(dashbase_searcher_reader_cache_oldest_timestamp{table=~'${table:pipe}',app='$app',component='searcher'} * 1000) by ($per)",
           "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(dashbase_searcher_payload_cache_size{component=\"indexer\",app=\"$app\"}) by ($per)",
-          "format": "time_series",
-          "hide": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "realtime - {{$per}}",
-          "refId": "B"
+          "legendFormat": "{{$per}}",
+          "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Payload Reader",
+      "title": "Oldest Segment Reader Cached",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -767,7 +857,8 @@
       },
       "yaxes": [
         {
-          "format": "none",
+          "$$hashKey": "object:721",
+          "format": "dateTimeFromNow",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -775,6 +866,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:722",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -795,7 +887,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 37
       },
       "id": 35,
       "panels": [],
@@ -812,10 +904,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 31,
@@ -827,6 +919,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -909,10 +1003,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 39,
@@ -1009,10 +1103,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 47
       },
       "hiddenSeries": false,
       "id": 37,
@@ -1102,10 +1196,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 47
       },
       "hiddenSeries": false,
       "id": 33,
@@ -1196,7 +1290,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 56
       },
       "id": 23,
       "panels": [],
@@ -1215,7 +1309,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 15,
@@ -1309,7 +1403,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 53
+        "y": 57
       },
       "hiddenSeries": false,
       "id": 17,
@@ -1404,7 +1498,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 62
+        "y": 66
       },
       "hiddenSeries": false,
       "id": 19,
@@ -1511,7 +1605,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 62
+        "y": 66
       },
       "hiddenSeries": false,
       "id": 21,
@@ -1701,10 +1795,11 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "$$hashKey": "object:319",
+          "selected": false,
           "tags": [],
-          "text": "table",
-          "value": "table"
+          "text": "instance",
+          "value": "instance"
         },
         "hide": 0,
         "includeAll": false,
@@ -1714,13 +1809,13 @@
         "options": [
           {
             "$$hashKey": "object:318",
-            "selected": true,
+            "selected": false,
             "text": "table",
             "value": "table"
           },
           {
             "$$hashKey": "object:319",
-            "selected": false,
+            "selected": true,
             "text": "instance",
             "value": "instance"
           }

--- a/provisioning/dashboards/Dashbase Searcher.json
+++ b/provisioning/dashboards/Dashbase Searcher.json
@@ -2,6 +2,7 @@
   "annotations": {
     "list": [
       {
+        "$$hashKey": "object:69",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -15,10 +16,11 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1590084041870,
+  "iteration": 1603918598625,
   "links": [],
   "panels": [
     {
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -34,13 +36,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 2,
       "interval": "",
       "legend": {
@@ -58,6 +63,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -70,13 +78,15 @@
         {
           "expr": "avg(rate(dashbase_searcher_query_latency_count{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by ($per)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "filter - {{$per}}",
+          "legendFormat": "{{$per}}",
           "refId": "A"
         },
         {
           "expr": "avg(rate(dashbase_realtime_searcher_query_latency_count{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by ($per)",
           "format": "time_series",
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}}",
           "refId": "B"
@@ -128,13 +138,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 3,
       "interval": "",
       "legend": {
@@ -152,6 +165,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -165,22 +181,24 @@
           "expr": "histogram_quantile(0.99, sum(rate(dashbase_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by (le, $per))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "full - {{$per}} - p99",
+          "legendFormat": "{{$per}} - p99",
           "refId": "C"
         },
         {
           "expr": "histogram_quantile(0.50, sum(rate(dashbase_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by (le, $per))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "full - {{$per}} - p50",
+          "legendFormat": "{{$per}} - p50",
           "refId": "D"
         },
         {
           "expr": "histogram_quantile(0.99, sum(rate(dashbase_realtime_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by (le, $per))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}} - p99",
           "refId": "E"
@@ -188,7 +206,7 @@
         {
           "expr": "histogram_quantile(0.50, sum(rate(dashbase_realtime_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='filter'}[$duration])) by (le, $per))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}} - p50",
           "refId": "F"
@@ -240,13 +258,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 27,
       "interval": "",
       "legend": {
@@ -264,6 +285,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -276,13 +300,15 @@
         {
           "expr": "avg(rate(dashbase_searcher_query_latency_count{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by ($per)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "filter - {{$per}}",
+          "legendFormat": "{{$per}}",
           "refId": "A"
         },
         {
           "expr": "avg(rate(dashbase_realtime_searcher_query_latency_count{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by ($per)",
           "format": "time_series",
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}}",
           "refId": "B"
@@ -334,13 +360,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 29,
       "interval": "",
       "legend": {
@@ -358,6 +387,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -371,22 +403,24 @@
           "expr": "histogram_quantile(0.99, sum(rate(dashbase_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by (le, $per))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "full - {{$per}} - p99",
+          "legendFormat": "{{$per}} - p99",
           "refId": "C"
         },
         {
           "expr": "histogram_quantile(0.50, sum(rate(dashbase_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by (le, $per))",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "full - {{$per}} - p50",
+          "legendFormat": "{{$per}} - p50",
           "refId": "D"
         },
         {
           "expr": "histogram_quantile(0.99, sum(rate(dashbase_realtime_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by (le, $per))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}} - p99",
           "refId": "E"
@@ -394,7 +428,7 @@
         {
           "expr": "histogram_quantile(0.50, sum(rate(dashbase_realtime_searcher_query_latency_bucket{table=~'${table:pipe}',app='$app',type='aggregation'}[$duration])) by (le, $per))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}} - p50",
           "refId": "F"
@@ -446,13 +480,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
         "y": 19
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "alignAsTable": true,
@@ -469,6 +506,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -486,30 +526,18 @@
         {
           "expr": "sum(delta(dashbase_searcher_num_segments_searched{component='searcher',table=~'${table:pipe}',app='$app'}[1m])) by ($per)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "full - {{$per}}",
+          "legendFormat": "{{$per}}",
           "refId": "C"
         },
         {
           "expr": "sum(delta(dashbase_searcher_num_segments_searched{component='indexer',table=~'${table:pipe}',app='$app'}[1m])) by ($per)",
           "format": "time_series",
+          "hide": true,
           "intervalFactor": 1,
           "legendFormat": "realtime - {{$per}}",
           "refId": "D"
-        },
-        {
-          "expr": "avg(delta(dashbase_searcher_num_segments_bloom_filter_checked{table=~'${table:pipe}',app='$app'}[1m]) / delta(dashbase_searcher_num_segments_searched{table=~'${table:pipe}',app='$app'}[1m])) by ($per)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "% bloom filter checked - {{$per}}",
-          "refId": "A"
-        },
-        {
-          "expr": "avg(delta(dashbase_searcher_num_segments_bloom_filtered{table=~'${table:pipe}',app='$app'}[1m]) / delta(dashbase_searcher_num_segments_searched{table=~'${table:pipe}',app='$app'}[1m])) by ($per)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "% filtered by bloom filter - {{$per}}",
-          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -558,13 +586,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "description": "the number of segment readers loaded into in-memory cache",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 19
       },
+      "hiddenSeries": false,
       "id": 11,
       "legend": {
         "alignAsTable": true,
@@ -581,6 +613,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -593,47 +628,130 @@
         {
           "expr": "sum(dashbase_searcher_reader_cache_count{app=\"$app\",table=~'${table:pipe}',component='searcher'}) by ($per)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "segment - full - {{$per}}",
+          "legendFormat": "{{$per}}",
           "refId": "A"
         },
         {
           "expr": "sum(dashbase_searcher_reader_cache_count{app=\"$app\",table=~'${table:pipe}',component='indexer'}) by ($per)",
           "format": "time_series",
+          "hide": true,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "segment - realtime - {{$per}}",
+          "legendFormat": "realtime - {{$per}}",
           "refId": "E"
-        },
-        {
-          "expr": "sum(dashbase_searcher_payload_cache_size{component=\"searcher\",app=\"$app\"})",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "payload - full",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(dashbase_searcher_payload_cache_size{component=\"indexer\",app=\"$app\"}) by ($per)",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "payload - realtime - {{$per}}",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(dashbase_searcher_num_bloom_filters_loaded{app=\"$app\",table=~'${table:pipe}'}) by ($per)",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "bloom filter - {{$per}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Cache",
+      "title": "Segment Reader Cached",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "the number of payload readers loaded into in-memory cache",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "dashbase_searcher_payload_cache_size{component=\"searcher\",app=\"$app\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(dashbase_searcher_payload_cache_size{component=\"indexer\",app=\"$app\"}) by ($per)",
+          "format": "time_series",
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "realtime - {{$per}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Payload Reader",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -672,11 +790,413 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
+      },
+      "id": 35,
+      "panels": [],
+      "title": "Bloom Filter",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "the number of segments whose bloom filters were loaded",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(dashbase_searcher_num_bloom_filters_loaded{app=\"$app\",table=~'${table:pipe}'}) by ($per)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{$per}}",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Loaded",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:287",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:288",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "the number of segments checked against / filtered by bloom filter",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 39,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(dashbase_searcher_num_segments_bloom_filter_checked{app=\"$app\",table=~'${table:pipe}',component='searcher'}[$duration])) by ($per)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "checked - {{$per}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(dashbase_searcher_num_segments_bloom_filtered{app=\"$app\",table=~'${table:pipe}',component='searcher'}[$duration])) by ($per)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "filtered - {{$per}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Checked / Filtered",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:583",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:584",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "hiddenSeries": false,
+      "id": 37,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "dashbase_searcher_bloom_filter_disk_available{app=\"$app\"} / dashbase_searcher_bloom_filter_disk_total{app=\"$app\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Available Disk Space",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:481",
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:482",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "total number of bloom filter files deleted to free disk space",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(dashbase_searcher_bloom_filter_files_deleted{app=\"$app\",table=~'${table:pipe}'}) by ($per)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{$per}}",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Deleted",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:382",
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:383",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
       },
       "id": 23,
       "panels": [],
@@ -690,12 +1210,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 53
       },
+      "hiddenSeries": false,
       "id": 15,
       "legend": {
         "alignAsTable": true,
@@ -714,6 +1236,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -779,12 +1304,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 53
       },
+      "hiddenSeries": false,
       "id": 17,
       "legend": {
         "alignAsTable": true,
@@ -803,6 +1330,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -813,8 +1343,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(jvm_cpu_usage_percent{component='searcher',app='$app'})",
+          "expr": "jvm_cpu_usage_percent{component='searcher',app='$app'}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -868,12 +1399,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 62
       },
+      "hiddenSeries": false,
       "id": 19,
       "legend": {
         "alignAsTable": true,
@@ -892,6 +1425,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -968,13 +1504,16 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 62
       },
+      "hiddenSeries": false,
       "id": 21,
       "legend": {
         "alignAsTable": true,
@@ -991,6 +1530,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1059,7 +1601,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 18,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1074,6 +1616,7 @@
         "definition": "label_values(jvm_attribute_uptime, app)",
         "hide": 0,
         "includeAll": false,
+        "index": -1,
         "label": null,
         "multi": false,
         "name": "app",
@@ -1092,6 +1635,7 @@
       {
         "allValue": ".*",
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1099,6 +1643,7 @@
         "definition": "label_values(jvm_attribute_uptime{app='$app'}, table)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": null,
         "multi": true,
         "name": "table",
@@ -1119,6 +1664,7 @@
         "auto_count": 30,
         "auto_min": "1m",
         "current": {
+          "selected": false,
           "text": "auto",
           "value": "$__auto_interval_duration"
         },
@@ -1167,11 +1713,13 @@
         "name": "per",
         "options": [
           {
+            "$$hashKey": "object:318",
             "selected": true,
             "text": "table",
             "value": "table"
           },
           {
+            "$$hashKey": "object:319",
             "selected": false,
             "text": "instance",
             "value": "instance"
@@ -1215,5 +1763,8 @@
   "timezone": "",
   "title": "Dashbase Searcher",
   "uid": "cAKMbk8Wz",
-  "version": 3
+  "variables": {
+    "list": []
+  },
+  "version": 5
 }

--- a/provisioning/dashboards/Dashbase Searcher.json
+++ b/provisioning/dashboards/Dashbase Searcher.json
@@ -1639,6 +1639,7 @@
         {
           "expr": "irate(jvm_gc_G1_Young_Generation_time{app='$app',component='searcher'}[$duration])",
           "format": "time_series",
+          "hide": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "young gen - {{instance}}",


### PR DESCRIPTION
Add a section for Searcher bloom filter.
![image](https://user-images.githubusercontent.com/847884/97503752-da82da80-1932-11eb-8429-a4828ed4b953.png)

Add a graph showing the timestamp of the oldest segment loaded into cache.
![image](https://user-images.githubusercontent.com/847884/97503812-f8503f80-1932-11eb-9d14-c2b095dd7cce.png)

Hide metrics for realtime segment searchers.

(core needs to be upgraded with https://github.com/dashbase/dashbase-engine/commit/2bd601a6adb20ac41cdf1e5c34496e94c730362b in order to show correct values in some graphs)