### PR TITLE
DASHBASE-142 add metrics for query time range and start time from now

### DIFF
--- a/provisioning/dashboards/Dashbase API.json
+++ b/provisioning/dashboards/Dashbase API.json
@@ -607,13 +607,193 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 43,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(dashbase_api_request_start_time_from_now_mins_sum{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[$duration])/rate(dashbase_api_request_start_time_from_now_mins_count{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[$duration])) by (table)",
+          "interval": "",
+          "legendFormat": "Average - $table",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Start Time from Now",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "m",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 44,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(dashbase_api_request_time_range_mins_sum{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[$duration])/rate(dashbase_api_request_time_range_mins_count{app=\"$app\", component=\"api\",table=~'${table:pipe}'}[$duration])) by (table)",
+          "interval": "",
+          "legendFormat": "Average - $table",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Time Range",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "m",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 16,
       "panels": [],
@@ -642,7 +822,7 @@
         "h": 9,
         "w": 6,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "id": 29,
       "interval": null,
@@ -714,7 +894,7 @@
         "h": 9,
         "w": 18,
         "x": 6,
-        "y": 28
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 2,
@@ -817,7 +997,7 @@
         "h": 9,
         "w": 6,
         "x": 0,
-        "y": 37
+        "y": 45
       },
       "id": 20,
       "interval": null,
@@ -889,7 +1069,7 @@
         "h": 9,
         "w": 18,
         "x": 6,
-        "y": 37
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 26,
@@ -988,7 +1168,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 54
       },
       "hiddenSeries": false,
       "id": 4,

--- a/provisioning/dashboards/Dashbase API.json
+++ b/provisioning/dashboards/Dashbase API.json
@@ -612,6 +612,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 2,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -675,6 +676,7 @@
       },
       "yaxes": [
         {
+          "decimals": 2,
           "format": "m",
           "label": null,
           "logBase": 1,
@@ -702,6 +704,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 2,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -765,6 +768,7 @@
       },
       "yaxes": [
         {
+          "decimals": 2,
           "format": "m",
           "label": null,
           "logBase": 1,


### PR DESCRIPTION
Add following metrics:
- `dashbase_api_request_start_time_from_now_mins` for recording start time from now (in minutes) in queries.
- `dashbase_api_request_time_range_mins` for recording time range (in minutes) in queries.

This is the result when doing queries with `24 hours ago ~ 1 hours ago`:
![image](https://user-images.githubusercontent.com/19381524/116242734-ce1ff300-a798-11eb-835d-d89070386497.png)
